### PR TITLE
Fix missing buildNamespace and default BASE_URL

### DIFF
--- a/lib/ImageGenerator.php
+++ b/lib/ImageGenerator.php
@@ -183,6 +183,22 @@ class ImageGenerator {
     }
 
     /**
+     * Build directory structure wrapper used by older APIs.
+     *
+     * In earlier versions a generic buildNamespace() method was exposed. The
+     * implementation was later renamed to buildNamespaceOnTimestamp(), leaving
+     * these calls broken.  Providing this wrapper maintains backwards
+     * compatibility and prevents fatal errors when the old method name is used.
+     *
+     * @param string $directory  Path to target directory.
+     * @param string $structure  Structure under target directory.
+     * @return boolean
+     */
+    public function buildNamespace($directory, $structure = NULL) {
+        return $this->buildNamespaceOnTimestamp($directory, $structure);
+    }
+
+    /**
      * Build directory structure for local images saving.
      * @param string $directory Path to target directory.
      * @param string $structure Structure under target directory.

--- a/lib/config.php
+++ b/lib/config.php
@@ -8,7 +8,8 @@
     |
     */
 
-    if (defined("BASE_URL")) {
+    // Define a default BASE_URL if one is not supplied by the application
+    if (!defined("BASE_URL")) {
         define("BASE_URL", "http://localhost:8888");
     }
     


### PR DESCRIPTION
## Summary
- add a backwards-compatible `buildNamespace()` wrapper to avoid fatal errors
- define a fallback BASE_URL constant when not provided
- ensure config file ends with newline

## Testing
- `php -l lib/ImageGenerator.php` *(fails: command not found)*
- `php -l lib/config.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857055b9478833292df9cf88a9ac89a